### PR TITLE
Add SQLite DataSource configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.xerial:sqlite-jdbc:3.42.0.0")
+    implementation("org.hibernate.orm:hibernate-community-dialects")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/src/main/java/com/example/demo/config/DataSourceConfig.java
+++ b/src/main/java/com/example/demo/config/DataSourceConfig.java
@@ -1,0 +1,18 @@
+package com.example.demo.config;
+
+import javax.sql.DataSource;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.sqlite.SQLiteDataSource;
+
+@Configuration
+public class DataSourceConfig {
+
+    @Bean
+    public DataSource dataSource() {
+        SQLiteDataSource dataSource = new SQLiteDataSource();
+        dataSource.setUrl("jdbc:sqlite:sample.db");
+        return dataSource;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,8 @@ server:
 spring:
   thymeleaf:
     cache: false
+  jpa:
+    database-platform: org.hibernate.community.dialect.SQLiteDialect
   security:
     oauth2:
       client:


### PR DESCRIPTION
## Summary
- add Spring Data JPA, SQLite JDBC, and Hibernate community dialect dependencies
- configure SQLite `DataSource` bean
- set JPA dialect to SQLite in application properties

## Testing
- `gradle --no-daemon test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.3.2'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab257552788320a1307b49c1752149