### PR TITLE
Configure SQLite datasource properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:sqlite:path/to/dbfile.db
+spring.datasource.driver-class-name=org.sqlite.JDBC
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect


### PR DESCRIPTION
## Summary
- add SQLite datasource configuration in application.properties

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab26d918748320bb05a60b7e3f72da