### PR TITLE
Add JPA User entity

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,20 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.xerial:sqlite-jdbc:3.42.0.0")
     implementation("org.hibernate.orm:hibernate-community-dialects")
+    compileOnly("org.projectlombok:lombok:1.18.32")
+    annotationProcessor("org.projectlombok:lombok:1.18.32")
+    testCompileOnly("org.projectlombok:lombok:1.18.32")
+    testAnnotationProcessor("org.projectlombok:lombok:1.18.32")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+configurations {
+    compileOnly {
+        extendsFrom(annotationProcessor.get())
+    }
+    testCompileOnly {
+        extendsFrom(testAnnotationProcessor.get())
+    }
 }
 
 tasks.test {

--- a/src/main/java/com/nayax/erp/user/User.java
+++ b/src/main/java/com/nayax/erp/user/User.java
@@ -1,0 +1,32 @@
+package com.nayax.erp.user;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "user")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    private String authProvider;
+
+    private String firstName;
+
+    private String lastName;
+}
+


### PR DESCRIPTION
## Summary
- add `User` entity with UUID id, unique email, and profile fields
- use Lombok to generate boilerplate and add Lombok dependencies

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68ab27aaf51c8320b90bc280ca956ab8