### PR TITLE
Add repository interface for user persistence

### DIFF
--- a/src/main/java/com/nayax/erp/user/UserRepository.java
+++ b/src/main/java/com/nayax/erp/user/UserRepository.java
@@ -1,0 +1,10 @@
+package com.nayax.erp.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByEmail(String email);
+}


### PR DESCRIPTION
## Summary
- add a Spring Data `UserRepository` extending `JpaRepository<User, UUID>`
- expose a `findByEmail` lookup method

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ab29f8c568832083a9aba8ffb86fa9