### PR TITLE
Persist new OAuth2 users

### DIFF
--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -3,7 +3,7 @@ package com.example.demo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"com.example.demo", "com.nayax.erp"})
 public class DemoApplication {
     public static void main(String[] args) {
         SpringApplication.run(DemoApplication.class, args);

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -2,27 +2,28 @@ package com.example.demo.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+
+import com.nayax.erp.user.AuthService;
 
 @Configuration
 public class SecurityConfig {
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain securityFilterChain(HttpSecurity http, AuthService authService) throws Exception {
         http
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/", "/css/**", "/js/**", "/images/**").permitAll()
                 .anyRequest().authenticated()
             )
-                .oauth2Login(o -> o
-                        .defaultSuccessUrl("/", true))
+            .oauth2Login(o -> o
+                .userInfoEndpoint(u -> u.userService(authService))
+                .defaultSuccessUrl("/", true))
             .logout(logout -> logout
                 .logoutSuccessUrl("/")
                 .invalidateHttpSession(true)
                 .clearAuthentication(true)
-                .deleteCookies("JSESSIONID")
-            );
+                .deleteCookies("JSESSIONID"));
         return http.build();
     }
 }

--- a/src/main/java/com/nayax/erp/user/AuthService.java
+++ b/src/main/java/com/nayax/erp/user/AuthService.java
@@ -1,0 +1,38 @@
+package com.nayax.erp.user;
+
+import java.util.UUID;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    public AuthService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oauth2User = super.loadUser(userRequest);
+
+        String email = oauth2User.getAttribute("email");
+        if (email != null && userRepository.findByEmail(email).isEmpty()) {
+            User user = User.builder()
+                    .id(UUID.randomUUID())
+                    .email(email)
+                    .authProvider(userRequest.getClientRegistration().getRegistrationId())
+                    .firstName(oauth2User.getAttribute("given_name"))
+                    .lastName(oauth2User.getAttribute("family_name"))
+                    .build();
+            userRepository.save(user);
+        }
+
+        return oauth2User;
+    }
+}


### PR DESCRIPTION
## Summary
- scan package for user management
- Save OAuth2 user info on first login
- Wire custom OAuth2 user service into security config

## Testing
- ⚠️ `./gradlew test` *(Proxy returns HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2add86bc83208fc58aeda51c6802