### PR TITLE
Log and rethrow OAuth2 authentication errors

### DIFF
--- a/src/main/java/com/example/demo/service/AuthService.java
+++ b/src/main/java/com/example/demo/service/AuthService.java
@@ -9,11 +9,14 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 public class AuthService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
+    private static final Logger log = LoggerFactory.getLogger(AuthService.class);
 
     public AuthService(UserRepository userRepository) {
         this.userRepository = userRepository;
@@ -25,8 +28,8 @@ public class AuthService extends DefaultOAuth2UserService {
         try {
             oauth2User = super.loadUser(userRequest);
         } catch (OAuth2AuthenticationException e) {
-
-            throw new RuntimeException(e);
+            log.error("Failed to load user from OAuth2 provider", e);
+            throw new OAuth2AuthenticationException(e.getError(), "Failed to load user from OAuth2 provider", e);
         }
 
         String email = oauth2User.getAttribute("email");


### PR DESCRIPTION
## Summary
- log OAuth2 user loading failures with SLF4J
- rethrow OAuth2AuthenticationException with descriptive message and original cause

## Testing
- ⚠️ `./gradlew test` *(failed: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68ab3c28ea6c8320b12353c88c18a716