### PR TITLE
Use OIDC user service for Google login

### DIFF
--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -17,7 +17,7 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
             )
             .oauth2Login(o -> o
-                .userInfoEndpoint(u -> u.userService(authService))
+                .userInfoEndpoint(u -> u.oidcUserService(authService))
                 .defaultSuccessUrl("/", true))
             .logout(logout -> logout
                 .logoutSuccessUrl("/")

--- a/src/main/java/com/example/demo/service/AuthService.java
+++ b/src/main/java/com/example/demo/service/AuthService.java
@@ -4,16 +4,16 @@ import java.util.UUID;
 
 import com.example.demo.entities.User;
 import com.example.demo.repository.UserRepository;
-import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
 
 @Service
-public class AuthService extends DefaultOAuth2UserService {
+public class AuthService extends OidcUserService {
 
     private final UserRepository userRepository;
     private static final Logger log = LoggerFactory.getLogger(AuthService.class);
@@ -23,27 +23,27 @@ public class AuthService extends DefaultOAuth2UserService {
     }
 
     @Override
-    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        OAuth2User oauth2User = null;
+    public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+        OidcUser oidcUser;
         try {
-            oauth2User = super.loadUser(userRequest);
+            oidcUser = super.loadUser(userRequest);
         } catch (OAuth2AuthenticationException e) {
             log.error("Failed to load user from OAuth2 provider", e);
-            throw new OAuth2AuthenticationException(e.getError(), "Failed to load user from OAuth2 provider", e);
+            throw e;
         }
 
-        String email = oauth2User.getAttribute("email");
+        String email = oidcUser.getEmail();
         if (email != null && userRepository.findByEmail(email).isEmpty()) {
             User user = User.builder()
                     .id(UUID.randomUUID())
                     .email(email)
                     .authProvider(userRequest.getClientRegistration().getRegistrationId())
-                    .firstName(oauth2User.getAttribute("given_name"))
-                    .lastName(oauth2User.getAttribute("family_name"))
+                    .firstName(oidcUser.getGivenName())
+                    .lastName(oidcUser.getFamilyName())
                     .build();
             userRepository.save(user);
         }
 
-        return oauth2User;
+        return oidcUser;
     }
 }


### PR DESCRIPTION
## Summary
- Switch AuthService to extend OidcUserService and handle OIDC users directly
- Configure Spring Security to use oidcUserService instead of generic OAuth2 user service

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3d5812648320bababc5b45fe3d1b