### PR TITLE
Persist users during OAuth2 login

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     testCompileOnly("org.projectlombok:lombok:1.18.32")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.32")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
 }
 
 configurations {

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -17,7 +17,7 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
             )
             .oauth2Login(o -> o
-                .userInfoEndpoint(u -> u.oidcUserService(authService))
+                .userInfoEndpoint(u -> u.userService(authService))
                 .defaultSuccessUrl("/", true))
             .logout(logout -> logout
                 .logoutSuccessUrl("/")

--- a/src/test/java/com/example/demo/service/OAuth2LoginIntegrationTest.java
+++ b/src/test/java/com/example/demo/service/OAuth2LoginIntegrationTest.java
@@ -1,0 +1,45 @@
+package com.example.demo.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.oauth2Login;
+
+import java.util.Optional;
+
+import com.example.demo.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OAuth2LoginIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @SpyBean
+    AuthService authService;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    void oauth2LoginInvokesAuthServiceAndPersistsNewUser() throws Exception {
+        when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+
+        mockMvc.perform(oauth2Login().attributes(attrs -> {
+            attrs.put("email", "new@example.com");
+            attrs.put("given_name", "New");
+            attrs.put("family_name", "User");
+        }));
+
+        verify(authService).loadUser(any());
+        verify(userRepository).save(any());
+    }
+}


### PR DESCRIPTION
## Summary
- Persist new users within a custom `DefaultOAuth2UserService` implementation
- Configure security to use the custom OAuth2 user service
- Add integration test verifying `loadUser` saves new users

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.3.2'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4ee6c3b483208da9c309583f0a31